### PR TITLE
[CHORE] no-action-hbs: action element modifier and named arguments handling.

### DIFF
--- a/transforms/no-action-hbs/__testfixtures__/basic.input.hbs
+++ b/transforms/no-action-hbs/__testfixtures__/basic.input.hbs
@@ -1,10 +1,14 @@
 {{action "methodName"}}
 {{action this.method param}}
 {{this.method}}
+{{action "methodName" param=value}}
+{{action "methodName" param param1=value}}
 
 <div
     onclick={{action "methodName"}}
     onclick={{action "methodName" param}}
+    onclick={{action "methodName" param param1=value}}
     {{on "click" (action "methodName")}}
+    {{on "click" (action "methodName" param param1=value)}}
 >
 </div>

--- a/transforms/no-action-hbs/__testfixtures__/basic.input.hbs
+++ b/transforms/no-action-hbs/__testfixtures__/basic.input.hbs
@@ -9,6 +9,10 @@
     onclick={{action "methodName" param}}
     onclick={{action "methodName" param param1=value}}
     {{on "click" (action "methodName")}}
+    {{on "click" (action "methodName" param)}}
     {{on "click" (action "methodName" param param1=value)}}
+    {{action "methodName" }}
+    {{action "methodName" param}}
+    {{action "methodName" param param1=value}}
 >
 </div>

--- a/transforms/no-action-hbs/__testfixtures__/basic.input.hbs
+++ b/transforms/no-action-hbs/__testfixtures__/basic.input.hbs
@@ -11,7 +11,7 @@
     {{on "click" (action "methodName")}}
     {{on "click" (action "methodName" param)}}
     {{on "click" (action "methodName" param param1=value)}}
-    {{action "methodName" }}
+    {{action "methodName"}}
     {{action "methodName" param}}
     {{action "methodName" param param1=value}}
 >

--- a/transforms/no-action-hbs/__testfixtures__/basic.output.hbs
+++ b/transforms/no-action-hbs/__testfixtures__/basic.output.hbs
@@ -11,7 +11,7 @@
     {{on "click" this.methodName}}
     {{on "click" (fn this.methodName param)}}
     {{on "click" (action "methodName" param param1=value)}}
-    {{on "click" this.methodName }}
+    {{on "click" this.methodName}}
     {{on "click" (fn this.methodName param)}}
     {{action "methodName" param param1=value}}
 >

--- a/transforms/no-action-hbs/__testfixtures__/basic.output.hbs
+++ b/transforms/no-action-hbs/__testfixtures__/basic.output.hbs
@@ -9,6 +9,10 @@
     onclick={{fn this.methodName param}}
     onclick={{action "methodName" param param1=value}}
     {{on "click" this.methodName}}
+    {{on "click" (fn this.methodName param)}}
     {{on "click" (action "methodName" param param1=value)}}
+    {{on "click" this.methodName }}
+    {{on "click" (fn this.methodName param)}}
+    {{action "methodName" param param1=value}}
 >
 </div>

--- a/transforms/no-action-hbs/__testfixtures__/basic.output.hbs
+++ b/transforms/no-action-hbs/__testfixtures__/basic.output.hbs
@@ -1,10 +1,14 @@
 {{this.methodName}}
 {{fn this.method param}}
 {{this.method}}
+{{action "methodName" param=value}}
+{{action "methodName" param param1=value}}
 
 <div
     onclick={{this.methodName}}
     onclick={{fn this.methodName param}}
+    onclick={{action "methodName" param param1=value}}
     {{on "click" this.methodName}}
+    {{on "click" (action "methodName" param param1=value)}}
 >
 </div>

--- a/transforms/no-action-hbs/index.js
+++ b/transforms/no-action-hbs/index.js
@@ -10,6 +10,11 @@ module.exports = function ({ source /*, path*/ }, { parse, visit }) {
           const firstParam = node.params[0];
           const secondParam = node.params[1];
 
+          // Skip transformation if there are named arguments
+          if (node.hash && node.hash.pairs.length > 0) {
+            return node;
+          }
+
           if (firstParam.type === 'StringLiteral' && secondParam) {
             // Transform {{action "methodName" param}} to {{fn this.methodName param}}
             return b.mustache(b.path('fn'), [
@@ -33,6 +38,11 @@ module.exports = function ({ source /*, path*/ }, { parse, visit }) {
         if (node.path.original === 'action') {
           const firstParam = node.params[0];
           const secondParam = node.params[1];
+
+          // Skip transformation if there are named arguments
+          if (node.hash && node.hash.pairs.length > 0) {
+            return node;
+          }
 
           if (firstParam.type === 'StringLiteral' && secondParam) {
             // Transform (action "methodName" param) to (fn this.methodName param)


### PR DESCRIPTION
- Handle action helper used as a element modifier replaced by {{on}} modifier 
- Handle named arguments in action helper transforms
- Keep original action helper when named arguments exist

Ex:
```
<div>{{action "methodName"}}</div>  -->  <div>{{on "click" this.methodName}}</div>
<div>{{action "methodName" param}}</ div> -->  <div>{{on "click" (fn this.methodName param)}}</div>
<div>{{action "methodName" arg=value}}</div> --> unchanged (keeps named args)
{{action "methodName" param=value}} --> unchanged (keeps named args)
{{action "methodName" param param1=value}} --> unchanged (keeps named args)
```